### PR TITLE
Manutenção importação bibliografica

### DIFF
--- a/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
@@ -11,6 +11,7 @@ import java.util.TreeSet;
 import org.jabref.logic.importer.fileformat.BibTeXMLImporter;
 import org.jabref.logic.importer.fileformat.BiblioscapeImporter;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.logic.importer.fileformat.CSVImporter;
 import org.jabref.logic.importer.fileformat.CopacImporter;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.importer.fileformat.EndnoteImporter;
@@ -68,6 +69,8 @@ public class ImportFormatReader {
         formats.add(new RepecNepImporter(importFormatPreferences));
         formats.add(new RisImporter());
         formats.add(new SilverPlatterImporter());
+        //adicionando o formato CSV
+        formats.add(new CSVImporter());
 
         // Get custom import formats
         for (CustomImporter importer : importFormatPreferences.getCustomImportList()) {

--- a/src/main/java/org/jabref/logic/importer/fileformat/CSVImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/CSVImporter.java
@@ -1,0 +1,84 @@
+package org.jabref.logic.importer.fileformat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jabref.logic.importer.Importer;
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.util.FileExtensions;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibtexEntryTypes;
+
+public class CSVImporter extends Importer {
+
+    @Override
+    public String getName() {
+        return "CSV";
+    }
+
+    @Override
+    public FileExtensions getExtensions() {
+        return FileExtensions.CSV;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Imports CSV files, where every field is separated by a semicolon.";
+    }
+
+    @Override
+    public boolean isRecognizedFormat(BufferedReader reader) throws IOException {
+    	String str;
+    	if(!reader.ready())
+    		return false;
+        str = reader.readLine();
+    	if(str.equals("BibliographyType,ISBN,Identifier,Author,Title,Journal,Volume,Number,Month,Pages,Year,Address,Note,URL,Booktitle,Chapter,Edition,Series,Editor,Publisher,ReportType,Howpublished,Institution,Organizations,School,Annote,Custom1,Custom2,Custom3,Custom4,Custom5"))
+    		return true; // this is discouraged except for demonstration purposes
+    	else
+    		return false;
+    }
+
+    @Override
+    public ParserResult importDatabase(BufferedReader input) throws IOException {
+        List<BibEntry> bibitems = new ArrayList<>();
+        
+        String primeiraLinha = input.readLine(); //descarta a primeira linha
+        primeiraLinha = primeiraLinha.replace("Identifier", "bibtexkey"); //mudando Identifier (nome que o JabRef salva a key) para bibtexkey
+        String [] campos = primeiraLinha.split(",");
+        String line = input.readLine();
+        while (line != null) {
+        	if (!line.trim().isEmpty()) {
+                String[] fields = line.split(",");
+                BibEntry entry = null;
+                //verificando o tipo da entrada com base no BibliographyType
+                switch(fields[0]) {
+                	case "1": entry = new BibEntry("book"); break;
+                	case "2": entry = new BibEntry("booklet"); break;
+                	case "3": entry = new BibEntry("proceedings"); break;
+                	case "5": entry = new BibEntry("inbook"); break;
+                	case "6": entry = new BibEntry("inproceedings"); break;
+                	case "7": entry = new BibEntry("article"); break;
+                	case "8": entry = new BibEntry("manual"); break;
+                	case "9": entry = new BibEntry("mastersthesis"); break;
+                	case "10": entry = new BibEntry("conference"); break;
+                	case "13": entry = new BibEntry("techreport"); break;
+                	case "14": entry = new BibEntry("unpublished"); break;
+                }
+                for(int i = 1; i < fields.length; i++) {                		
+            		if(!fields[i].contains("\"\"")) { //verificando se nao é vazio
+            			if(fields[i].contains("\"")) //verificando se nao é interio
+            				entry.setField(campos[i],fields[i].substring(1,fields[i].length()-1));
+            			else
+            				entry.setField(campos[i],fields[i]); 
+            		}
+                }
+                bibitems.add(entry);
+                line = input.readLine();
+            }
+        }
+        return new ParserResult(bibitems);
+    }
+
+}

--- a/src/main/java/org/jabref/logic/util/FileExtensions.java
+++ b/src/main/java/org/jabref/logic/util/FileExtensions.java
@@ -15,6 +15,7 @@ public enum FileExtensions {
     //important: No dot before the extension!
     BIBTEX_DB(String.format("%1s %2s", "BibTex", Localization.lang("Library")), "bib"),
     BIBTEXML(Localization.lang("%0 file", "BibTeXML"), "bibx", "xml"),
+    CSV(Localization.lang("%0 file", "CSV"), "csv"),
     BILBIOSCAPE(Localization.lang("%0 file", "Biblioscape"), "txt"),
     COPAC(Localization.lang("%0 file", "Copac"), "txt"),
     CITATION_STYLE(Localization.lang("%0 file", "CSL"), "csl"),


### PR DESCRIPTION
Foram feitas as manutenções necessárias como a criação de uma classe para a importação de CSV, e adição nas classes referentes de importação para a possibilidade de oferecer a importação em CSV. Também foi feitas manutenções para oferecer a opção de adicionar em uma nova Database quando existirem duplicatas no Database atual.
Com isso, a issue #6 foi resolvida (resolve #6).