### PR TITLE
Adição do arquivo de teste do Dropbox

### DIFF
--- a/src/test/java/TestesES2/DropboxTestes.java
+++ b/src/test/java/TestesES2/DropboxTestes.java
@@ -1,0 +1,23 @@
+package TestesES2;
+
+import org.jabref.gui.exporter.Dropbox.ExportDropbox;
+import org.junit.Test;
+
+import com.dropbox.core.DbxException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class DropboxTestes {
+
+    @Test
+    public void ExportDropboxTeste() {
+        try {
+			ExportDropbox.funcDropbox("2DcE7b1wPzAAAAAAAAAAI7ELkyHpL-se0p4iMLWpaB0kcLGqa1CeZlQi23Vru5_o",
+					new ByteArrayInputStream((new String("teste")).getBytes()));
+		} catch (DbxException | IOException e) {
+			e.printStackTrace();
+		}
+    }   
+}
+


### PR DESCRIPTION
Foi criado um teste da função de upload de arquivos para o Dropbox. No teste, o "arquivo" era nada mais que uma string, e foi usado um token dado pela API do Dropbox.

Com isso, a issue #15  foi resolvido (resolve #15).